### PR TITLE
Update Typescript types to fix error

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,5 @@
-import {Tags} from "node-id3";
-
 declare module "node-id3" {
+   import {Tags} from "node-id3";
    namespace NodeID3 {
       export interface Tags {
          /**


### PR DESCRIPTION
Fix the same kind of Typescript error described here:
https://github.com/cinnamon-bun/node-id3/edit/master/index.d.ts

Otherwise you get this error when building Typescript:
"Exports and export assignments are not permitted in module augmentations"